### PR TITLE
New option in submit.sh for Lumi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Installation for 76X (2015)
-```bash 
+```bash
 export SCRAM_ARCH=slc6_amd64_gcc493
 scramv1 project CMSSW CMSSW_7_6_3_patch2
 cd CMSSW_7_6_3_patch2/src/
@@ -23,7 +23,11 @@ cd $CMSSW_BASE/src
 scram b -j 8
 
 
-git clone -b svFit_2015Apr03 https://github.com/veelken/SVfit_standalone.git TauAnalysis/SVfitStandalone
+#git clone -b svFit_2015Apr03 https://github.com/veelken/SVfit_standalone.git TauAnalysis/SVfitStandalone
+
+# SVFit for 2016/2017 analyses
+git clone git@github.com:veelken/SVfit_standalone.git TauAnalysis/SVfitStandalone
+git checkout HIG-16-006
 
 git clone https://github.com/cms2l2v/2l2v_fwk.git UserCode/llvv_fwk
 cd UserCode/llvv_fwk
@@ -39,7 +43,7 @@ scramv1 b -j 16 #WARNING: this won't work! You first need to do "Step to use MEL
 ```
 
 #Step to use MELA
-```bash 
+```bash
 cd CMSS_X_Y_Z/src
 git clone https://github.com/cms-analysis/HiggsAnalysis-ZZMatrixElement.git ZZMatrixElement
 cd ZZMatrixElement
@@ -55,14 +59,14 @@ scram b -j 12
 Please before doing your PR, be sure to:
  - test your changes
  - reverse the changes due to th1fmorph thanks to the following command (and be sure to not add those new files in your git add):
-```bash 
+```bash
 #TO DO before a PR
 cd $CMSSW_BASE/src
 find UserCode/llvv_fwk/ -type f -name '*.cc' -exec sed -i -e 's/UserCode\/llvv_fwk\/interface\/th1fmorph.h/HiggsAnalysis\/CombinedLimit\/interface\/th1fmorph.h/g' {} \;
 ```
  - then you can make your PR
  - if you want to continue developing, don't forget to reverse this once again:
-```bash 
+```bash
 #TO DO after a PR to be able to continue to work
 cd $CMSSW_BASE/src
 find UserCode/llvv_fwk/ -type f -name '*.cc' -exec sed -i -e 's/HiggsAnalysis\/CombinedLimit\/interface\/th1fmorph.h/UserCode\/llvv_fwk\/interface\/th1fmorph.h/g' {} \;
@@ -76,7 +80,7 @@ We have decided to use pull-request mode for the master development.
 - Fork the code with your personal github ID. See [details](https://help.github.com/articles/fork-a-repo/)
 - Make a clean git clone in the UserCode directory
 ```
-cd $CMSSW_BASE/src/UserCode 
+cd $CMSSW_BASE/src/UserCode
 git clone git@github.com:yourgithubid/2l2v_fwk.git llvv_fwk
 cd llvv_fwk
 git remote add upstream git@github.com:cms2l2v/2l2v_fwk.git
@@ -116,4 +120,3 @@ runLocalAnalysisOverSamples.py -e my_exe -j data/my_samples.json -d my_input_dir
  of your analysis.  The executable can also be added in the
  UserCode/llvv_fwk/test/hzz2l2nu/bin directory (also add it to the
  Buildfile there)
-

--- a/bin/zhtautau/runZHTauTauAnalysis.cc
+++ b/bin/zhtautau/runZHTauTauAnalysis.cc
@@ -75,30 +75,77 @@ LorentzVector getSVFit(pat::MET met, std::vector<patUtils::GenericLepton> selLep
 
   TMatrixD covMET(2, 2); // PFMET significance matrix
   // FIXME in MINIAODv2 74X, covariance is always 0000
-  //  covMET[0][0] = met.getSignificanceMatrix()(0,0);
-  //  covMET[0][1] = met.getSignificanceMatrix()(0,1);
-  //  covMET[1][0] = met.getSignificanceMatrix()(1,0);
-  //  covMET[1][1] = met.getSignificanceMatrix()(1,1);
+   covMET[0][0] = met.getSignificanceMatrix()(0,0);
+   covMET[0][1] = met.getSignificanceMatrix()(0,1);
+   covMET[1][0] = met.getSignificanceMatrix()(1,0);
+   covMET[1][1] = met.getSignificanceMatrix()(1,1);
   //  std::cout<<"MET MATRIX: " << covMET[0][0] << " " << covMET[0][1] << " " << covMET[1][0] << " " << covMET[1][1] << "\n";
 
   int dlid = abs( selLeptons[higgsCandL1].pdgId() * selLeptons[higgsCandL2].pdgId() );
 
+  std::cout<<"\n"<<selLeptons[higgsCandL1].pdgId() << "  " << selLeptons[higgsCandL2].pdgId() << " Di-Tau ID ------------> " << dlid << std::endl;
+
   if ( dlid == 165 || dlid == 195){
-    higgsCandL1  = abs(selLeptons[higgsCandL1].pdgId()) != 15 ? higgsCandL1 : higgsCandL2;
-    higgsCandL2  = abs(selLeptons[higgsCandL1].pdgId()) != 15 ? higgsCandL2 : higgsCandL1;
+    if (abs(selLeptons[higgsCandL1].pdgId()) == 15) {
+      // Switching leptons in semileptonic pairs:
+      // e and mu should be passed as first MesuredTauLepton
+      int temp = higgsCandL1;
+      higgsCandL1  = higgsCandL2;
+      higgsCandL2  = temp;
+    }
   }
 
-  covMET[0][0] = 0.95;  covMET[0][1] = 0.05; covMET[1][0] = 0.05; covMET[1][1] = 0.95;
+  // covMET[0][0] = 0.95;  covMET[0][1] = 0.05; covMET[1][0] = 0.05; covMET[1][1] = 0.95;
 
   std::vector<svFitStandalone::MeasuredTauLepton> measuredTauLeptons;
-  measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(abs(selLeptons[higgsCandL1].pdgId())==15?svFitStandalone::kTauToHadDecay:abs(selLeptons[higgsCandL1].pdgId())==11?svFitStandalone::kTauToElecDecay:svFitStandalone::kTauToMuDecay,selLeptons[higgsCandL1].pt(), selLeptons[higgsCandL1].eta(), selLeptons[higgsCandL1].phi(), selLeptons[higgsCandL1].mass() ));
-  measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(abs(selLeptons[higgsCandL2].pdgId())==15?svFitStandalone::kTauToHadDecay:abs(selLeptons[higgsCandL2].pdgId())==11?svFitStandalone::kTauToElecDecay:svFitStandalone::kTauToMuDecay, selLeptons[higgsCandL2].pt(), selLeptons[higgsCandL2].eta(), selLeptons[higgsCandL2].phi(), selLeptons[higgsCandL2].mass() ));
 
-  SVfitStandaloneAlgorithm algo(measuredTauLeptons, met.px(), met.py() , covMET, 0);
+   if ( dlid == 165 ){
+        //std::cout<< " ETau Pair --- > "<< selLeptons[higgsCandL1].pdgId() << "  " << selLeptons[higgsCandL2].pdgId() << std::endl;
+        measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToElecDecay, selLeptons[higgsCandL1].pt(), selLeptons[higgsCandL1].eta(),
+                                   selLeptons[higgsCandL1].phi(), svFitStandalone::electronMass) );
+        measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToHadDecay, selLeptons[higgsCandL2].pt(), selLeptons[higgsCandL2].eta(),
+                                   selLeptons[higgsCandL2].phi(), selLeptons[higgsCandL2].mass(), selLeptons[higgsCandL2].tau.decayMode()) );
+      }
+  else if( dlid == 195 ){
+      //std::cout<< " MuTau Pair --- > "<< selLeptons[higgsCandL1].pdgId() << "  " << selLeptons[higgsCandL2].pdgId() << std::endl;
+      measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToMuDecay, selLeptons[higgsCandL1].pt(), selLeptons[higgsCandL1].eta(),
+                                   selLeptons[higgsCandL1].phi(), svFitStandalone::muonMass) );
+      measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToHadDecay, selLeptons[higgsCandL2].pt(), selLeptons[higgsCandL2].eta(),
+                                   selLeptons[higgsCandL2].phi(), selLeptons[higgsCandL2].mass(), selLeptons[higgsCandL2].tau.decayMode()) );
+    }
+  else if ( dlid == 225 ){
+      //std::cout<< " TauTau Pair --- > "<< selLeptons[higgsCandL1].pdgId() << "  " << selLeptons[higgsCandL2].pdgId() << std::endl;
+       measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToHadDecay, selLeptons[higgsCandL1].pt(), selLeptons[higgsCandL1].eta(),
+                                 selLeptons[higgsCandL1].phi(), selLeptons[higgsCandL1].mass(), selLeptons[higgsCandL1].tau.decayMode()) );
+       measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(svFitStandalone::kTauToHadDecay, selLeptons[higgsCandL2].pt(), selLeptons[higgsCandL2].eta(),
+                                 selLeptons[higgsCandL2].phi(), selLeptons[higgsCandL2].mass(), selLeptons[higgsCandL2].tau.decayMode()) );
+    }
+    else return LorentzVector(selLeptons[higgsCandL1].p4()+selLeptons[higgsCandL2].p4());
+  // measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(abs(selLeptons[higgsCandL1].pdgId())==15?svFitStandalone::kTauToHadDecay:abs(selLeptons[higgsCandL1].pdgId())==11?svFitStandalone::kTauToElecDecay:svFitStandalone::kTauToMuDecay,
+  //                               selLeptons[higgsCandL1].pt(),
+  //                               selLeptons[higgsCandL1].eta(),
+  //                               selLeptons[higgsCandL1].phi(),
+  //                               selLeptons[higgsCandL1].mass() ));
+  // measuredTauLeptons.push_back(svFitStandalone::MeasuredTauLepton(abs(selLeptons[higgsCandL2].pdgId())==15?svFitStandalone::kTauToHadDecay:abs(selLeptons[higgsCandL2].pdgId())==11?svFitStandalone::kTauToElecDecay:svFitStandalone::kTauToMuDecay,
+  //                              selLeptons[higgsCandL2].pt(),
+  //                              selLeptons[higgsCandL2].eta(),
+  //                              selLeptons[higgsCandL2].phi(),
+  //                              selLeptons[higgsCandL2].mass() ));
+
+  SVfitStandaloneAlgorithm algo(measuredTauLeptons, met.px(), met.py() , covMET, 2);
   algo.addLogM(false);
-  algo.fit();
-  if(algo.isValidSolution()){
-    return algo.fittedDiTauSystem();
+  edm::FileInPath inputFileName_visPtResolution("TauAnalysis/SVfitStandalone/data/svFitVisMassAndPtResolutionPDF.root");
+  TH1::AddDirectory(false);
+  TFile* inputFile_visPtResolution = new TFile(inputFileName_visPtResolution.fullPath().data());
+  algo.shiftVisPt(true, inputFile_visPtResolution);
+  algo.integrateMarkovChain();
+
+  double mass = algo.getMass(); // Full SVFit mass - return value is in units of GeV
+  //double transverse_mass = algo.getTransverseMass(); // Transverse SVFit mass
+  if ( algo.isValidSolution() ) {
+    std::cout << "found mass = " << mass << std::endl;
+  } else {
+    std::cout << "sorry -- status of NLL is not valid [" << algo.fitStatus() << "]" << std::endl;
   }
   return LorentzVector(selLeptons[higgsCandL1].p4()+selLeptons[higgsCandL2].p4());
 }
@@ -1319,12 +1366,12 @@ int main(int argc, char* argv[])
           //SVFIT MASS
           higgsCand_SVFit = higgsCand;
 
-        //   //FIXME gives a lot of warning currently
-        //  if(passZmass && passZpt && passDPhiCut && passHiggsLoose && passLepVetoMain && passBJetVetoMain){
-        //  // std::cout<<"START SVFIT\n";
-        //   higgsCand_SVFit = getSVFit(met, selLeptons, higgsCandL1, higgsCandL2);  //compute svfit mass in a smart way
-        // //  std::cout<<"END SVFIT\n";
-        //  }
+          //FIXME gives a lot of warning currently
+       //  if(passZmass && passZpt && passDPhiCut && passHiggsLoose && passLepVetoMain && passBJetVetoMain){
+         // std::cout<<"START SVFIT\n";
+       //   higgsCand_SVFit = getSVFit(met, selLeptons, higgsCandL1, higgsCandL2);  //compute svfit mass in a smart way
+        //  std::cout<<"END SVFIT\n";
+       //  }
 
           //build the higgs candH
           higgsCandH = zll + higgsCand;


### PR DESCRIPTION
### modified:   test/zhtautau/submit.sh
- option 2.1 added to the script. It allows to compute the IntLumi on lxplus
  gathering the LUMI.txt on ingrid

**HOW to USE IT:** 
./submit.sh 2.1
1. It creates the usual json file
2. It asks for you lxplus username
3. It copies the json file to your ~/private [Password required]
4. It sets up and launches brilCalc [Password required]
5. It copy part of the output generated by point 4 in **$RESULTSDIR/LUMI.txt** on your local cluster

### modified:   bin/zhtautau/runZHTauTauAnalysis.cc
- some changes in the SVFit function
  + pair ordering in the semi-leptonic channels
  + markovchain integration
  + met cov matrix values
- SVFit still disable!

### modified:  README.md
- SVFit 2016 recipe