### PR TITLE
use same lepton thresholds as UW + fix signal cross-section

### DIFF
--- a/bin/zhtautau/runZHTauTauAnalysis.cc
+++ b/bin/zhtautau/runZHTauTauAnalysis.cc
@@ -1667,7 +1667,7 @@ int main(int argc, char* argv[])
         for(unsigned int l1=0   ;l1<selLeptons.size();l1++){
           if(abs(selLeptons[l1].pdgId())==15)continue;
 
-          double leadPtCutValue  = abs(selLeptons[l1].pdgId())==11 ? 30.0 : 25.0;
+          double leadPtCutValue  = abs(selLeptons[l1].pdgId())==11 ? 24.0 : 18.0;
           if( selLeptons[l1].pt()< leadPtCutValue ) continue;
           if(!( abs(selLeptons[l1].pdgId())==11 ? patUtils::passIso(selLeptons[l1].el,  patUtils::llvvElecIso::Tight, patUtils::CutVersion::CutSet::ICHEP16Cut) :
                                                 patUtils::passIso(selLeptons[l1].mu,  patUtils::llvvMuonIso::Tight, patUtils::CutVersion::CutSet::Moriond17Cut)) ||
@@ -1677,7 +1677,7 @@ int main(int argc, char* argv[])
           for(unsigned int l2=l1+1;l2<selLeptons.size();l2++){
             if(abs(selLeptons[l2].pdgId())==15)continue;
 
-            double trailPtCutValue = abs(selLeptons[l1].pdgId())==11 ? 15.0 : 10.0;
+            double trailPtCutValue = abs(selLeptons[l1].pdgId())==11 ? 13.0 : 10.0;
             if( selLeptons[l2].pt() < trailPtCutValue ) continue;
             if(!( abs(selLeptons[l2].pdgId())==11 ? patUtils::passIso(selLeptons[l2].el,  patUtils::llvvElecIso::Tight, patUtils::CutVersion::CutSet::ICHEP16Cut) :
                                                   patUtils::passIso(selLeptons[l2].mu,  patUtils::llvvMuonIso::Tight, patUtils::CutVersion::CutSet::Moriond17Cut)) ||

--- a/test/zhtautau/samples.json
+++ b/test/zhtautau/samples.json
@@ -63,7 +63,7 @@
       "color":4,
       "lcolor":1,
       "data":[
-             { "dtag":"ZHToTauTau_M125_13TeV_powheg_pythia8"  ,  "xsec":0.00265 , "br":[ 1.0 ]            , "dset":["/ZHToTauTau_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"]}
+             { "dtag":"ZHToTauTau_M125_13TeV_powheg_pythia8"  ,  "xsec":0.05785  , "br":[ 1.0 ]            , "dset":["/ZHToTauTau_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"]}
       ]
     },
     {


### PR DESCRIPTION
For reference: [presentation from UW](https://indico.cern.ch/event/628847/contributions/2729165/attachments/1527911/2389868/ZH_Update_Ruggles_20170921.pdf).
Twiki: https://twiki.cern.ch/twiki/bin/viewauth/CMS/AZh-Htautau2016